### PR TITLE
Fix tag generation for images that no longer exist on master but do exist in older branches

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -110,10 +110,6 @@ for branch in "${branches[@]}"; do
 	for dir in "${directories[@]}"; do
 		# shellcheck disable=SC2001
 		dir="$(echo "$dir" | sed -e 's/[[:space:]]*$//')"
-		if [ ! -d "$dir" ]; then
-			# skip directory that doesn't exist in this branch
-			continue
-		fi
 
 		dockerfile="$(git show "$commit:$dir/Dockerfile")"
 


### PR DESCRIPTION
See also:
https://github.com/gradle/docker-gradle/commit/b389ed86aeb8b63d2b3d518054503831a4411214