### PR TITLE
Unpack the gradle distributions without restoring timestamps from the archive in an attempt to fix #210

### DIFF
--- a/jdk-lts-and-current-alpine/Dockerfile
+++ b/jdk-lts-and-current-alpine/Dockerfile
@@ -37,6 +37,7 @@ RUN set -o errexit -o nounset \
       curl \
       wget \
       tar \
+      unzip \
       \
       # VCSes
       breezy \
@@ -75,7 +76,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk-lts-and-current-corretto/Dockerfile
+++ b/jdk-lts-and-current-corretto/Dockerfile
@@ -80,7 +80,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle \

--- a/jdk-lts-and-current-graal/Dockerfile
+++ b/jdk-lts-and-current-graal/Dockerfile
@@ -151,7 +151,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle \

--- a/jdk-lts-and-current/Dockerfile
+++ b/jdk-lts-and-current/Dockerfile
@@ -84,7 +84,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle \

--- a/jdk17-alpine/Dockerfile
+++ b/jdk17-alpine/Dockerfile
@@ -26,6 +26,7 @@ RUN set -o errexit -o nounset \
       curl \
       wget \
       tar \
+      unzip \
       \
       # VCSes
       breezy \
@@ -64,7 +65,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk17-corretto/Dockerfile
+++ b/jdk17-corretto/Dockerfile
@@ -70,7 +70,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk17-jammy-graal/Dockerfile
+++ b/jdk17-jammy-graal/Dockerfile
@@ -118,7 +118,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk17-jammy/Dockerfile
+++ b/jdk17-jammy/Dockerfile
@@ -69,7 +69,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk17-noble-graal/Dockerfile
+++ b/jdk17-noble-graal/Dockerfile
@@ -120,7 +120,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk17-noble/Dockerfile
+++ b/jdk17-noble/Dockerfile
@@ -72,7 +72,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk17-ubi9/Dockerfile
+++ b/jdk17-ubi9/Dockerfile
@@ -68,7 +68,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk21-alpine/Dockerfile
+++ b/jdk21-alpine/Dockerfile
@@ -26,6 +26,7 @@ RUN set -o errexit -o nounset \
       curl \
       wget \
       tar \
+      unzip \
       \
       # VCSes
       breezy \
@@ -64,7 +65,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk21-corretto/Dockerfile
+++ b/jdk21-corretto/Dockerfile
@@ -71,7 +71,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk21-jammy-graal/Dockerfile
+++ b/jdk21-jammy-graal/Dockerfile
@@ -117,7 +117,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk21-jammy/Dockerfile
+++ b/jdk21-jammy/Dockerfile
@@ -70,7 +70,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk21-noble-graal/Dockerfile
+++ b/jdk21-noble-graal/Dockerfile
@@ -119,7 +119,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk21-noble/Dockerfile
+++ b/jdk21-noble/Dockerfile
@@ -72,7 +72,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk21-ubi9/Dockerfile
+++ b/jdk21-ubi9/Dockerfile
@@ -68,7 +68,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk25-alpine/Dockerfile
+++ b/jdk25-alpine/Dockerfile
@@ -26,6 +26,7 @@ RUN set -o errexit -o nounset \
       curl \
       wget \
       tar \
+      unzip \
       \
       # VCSes
       breezy \
@@ -64,7 +65,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum -c - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk25-corretto/Dockerfile
+++ b/jdk25-corretto/Dockerfile
@@ -71,7 +71,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk25-noble-graal/Dockerfile
+++ b/jdk25-noble-graal/Dockerfile
@@ -119,7 +119,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk25-noble/Dockerfile
+++ b/jdk25-noble/Dockerfile
@@ -72,7 +72,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle

--- a/jdk25-ubi10/Dockerfile
+++ b/jdk25-ubi10/Dockerfile
@@ -68,7 +68,7 @@ RUN set -o errexit -o nounset \
     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
     \
     && echo "Installing Gradle" \
-    && unzip gradle.zip \
+    && unzip -DD gradle.zip \
     && rm gradle.zip \
     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
     && ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle


### PR DESCRIPTION
- **Unpack the gradle distributions without restoring timestamps from the archive**, fixes #210
