### PR TITLE
Explicitly define workflow permission

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: GitHub CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gradle/docker-gradle/security/code-scanning/1](https://github.com/gradle/docker-gradle/security/code-scanning/1)

The best way to fix the problem is to explicitly set the `permissions` key in the workflow file to restrict the GITHUB_TOKEN privileges to the minimum required for the workflow. Since this workflow only checks out code and builds/tests it (does not push, create releases, or otherwise need `write` permissions), specifying `permissions: contents: read` at the workflow root is adequate and follows best practices. This should be inserted immediately below the `name:` key and before the `on:` key to apply to all jobs in the workflow.

No changes to imports, methods, or further regions are needed—just the top-level addition of the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
