### PR TITLE
Revert "jdk-lts-and-current-corretto: Update current to Java 26"

### DIFF
--- a/jdk-lts-and-current-corretto/Dockerfile
+++ b/jdk-lts-and-current-corretto/Dockerfile
@@ -1,8 +1,9 @@
 FROM amazoncorretto:25-al2023-jdk
 
-COPY --from=amazoncorretto:26-al2023-jdk /usr/lib/jvm/java-26-amazon-corretto /usr/lib/jvm/java-26-amazon-corretto
+# We need this again when Java 26 comes out
+#COPY --from=amazoncorretto:26-al2023-jdk /usr/lib/jvm/java-26-amazon-corretto /usr/lib/jvm/java-26-amazon-corretto
 ENV JAVA_LTS_HOME=/usr/lib/jvm/java-25-amazon-corretto
-ENV JAVA_CURRENT_HOME=/usr/lib/jvm/java-26-amazon-corretto
+ENV JAVA_CURRENT_HOME=/usr/lib/jvm/java-25-amazon-corretto
 
 CMD ["gradle"]
 


### PR DESCRIPTION
This reverts commit bc3650ebb324b51574794a51ff8eb59d7cd596cf.


So we can ship 9.4.1 to all the same images that had 9.4.0 before we add Java 26 images (or modify images for Java 26)