### PR TITLE
Add Dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 7 # don't immediately create PRs for available updates
+    schedule:
+      interval: "daily"
+    labels:
+      - "@dev-productivity"


### PR DESCRIPTION
- Add `.github/dependabot.yml` to enable automated version updates for GitHub Actions
- Configured with daily checks and a 7-day cooldown to batch updates and reduce PR noise
- PRs are auto-labeled with `@dev-productivity`