### PR TITLE
Limit directory commit search to merge commits on first-parent history

### DIFF
--- a/generate-stackbrew-library.py
+++ b/generate-stackbrew-library.py
@@ -74,8 +74,8 @@ def get_directories(commit):
     return dirs
 
 def get_directory_commit(branch_commit, dir_path):
-    """Get the last commit that changed the given directory."""
-    output = run_command(["git", "log", "-1", "--format=%H", branch_commit, "--", f"{dir_path}/"])
+    """Get the last merge commit on the first-parent history that changed the given directory."""
+    output = run_command(["git", "log", "-1", "--first-parent", "--merges", "--format=%H", branch_commit, "--", f"{dir_path}/"])
     return output.strip()
 
 def get_arches(image, cache):


### PR DESCRIPTION
- Restrict `get_directory_commit()` to only consider merge commits on the first-parent history using `--first-parent --merges`
- Prevents picking up commits from within feature branches that aren't on the main line