### PR TITLE
Improve directory-specific GitCommit for Gradle 8+

### DIFF
--- a/generate-stackbrew-library.py
+++ b/generate-stackbrew-library.py
@@ -74,8 +74,8 @@ def get_directories(commit):
     return dirs
 
 def get_directory_commit(branch_commit, dir_path):
-    """Get the last merge commit on the first-parent history that changed the given directory."""
-    output = run_command(["git", "log", "-1", "--first-parent", "--merges", "--format=%H", branch_commit, "--", f"{dir_path}/"])
+    """Get the latest commit on the first-parent history that changed the given directory."""
+    output = run_command(["git", "log", "-1", "--first-parent", "--format=%H", branch_commit, "--", f"{dir_path}/"])
     return output.strip()
 
 def get_arches(image, cache):

--- a/generate-stackbrew-library.py
+++ b/generate-stackbrew-library.py
@@ -150,7 +150,7 @@ def main():
 
         first_version = None
         for dir_path in directories:
-            dir_commit = get_directory_commit(commit, dir_path)
+            dir_commit = get_directory_commit(commit, dir_path) if int(major) >= 8 else commit
             dockerfile = run_command(["git", "show", f"{dir_commit}:{dir_path}/Dockerfile"])
 
             # Extract FROM


### PR DESCRIPTION
- Only use directory-specific commit lookup for Gradle versions 8+; older versions keep using the branch head commit
  - To avoid touching older Gradle images as they do not have relevant changes
- Drop `--merges` flag so both merge commits and direct pushes on the first-parent history are considered, ensuring the latest change to a directory is always used as reference