### PR TITLE
Update Graal versions and release lookup

### DIFF
--- a/jdk-lts-and-current-graal/Dockerfile
+++ b/jdk-lts-and-current-graal/Dockerfile
@@ -87,13 +87,15 @@ RUN set -o errexit -o nounset \
     && mkdir /opt/java \
     \
     && echo "Downloading LTS GraalVM" \
-    && JAVA_LTS_VERSION=25.0.2 \
-    && GRAALVM_LTS_AMD64_DOWNLOAD_SHA256=e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0 \
-    && GRAALVM_LTS_AARCH64_DOWNLOAD_SHA256=b4580d9f223d0a4b3a1757e58b18ff4c1db950e67e105fc5cb741457d2384a71 \
+    && JAVA_LTS_VERSION=25.0.4 \
+    && GRAALVM_LTS_AMD64_DOWNLOAD_SHA256=3f4a89de8eaa96f2ed677f09957c7e872cd8467aad3537f8b5394c1b8c4b942e \
+    && GRAALVM_LTS_AARCH64_DOWNLOAD_SHA256=22286f7ecd21b9aedb3226b9bf797469e1bd3eefc491e12ef3dd49b452d230b7 \
     && ARCHITECTURE=$(dpkg --print-architecture) \
     && if [ "${ARCHITECTURE}" = "amd64" ]; then GRAALVM_ARCHITECTURE=linux-x64; fi \
     && if [ "${ARCHITECTURE}" = "arm64" ]; then GRAALVM_ARCHITECTURE=linux-aarch64; fi \
-    && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${JAVA_LTS_VERSION}/graalvm-community-jdk-${JAVA_LTS_VERSION}_${GRAALVM_ARCHITECTURE}_bin.tar.gz \
+    && GRAALVM_RELEASE_TAG=graal-25.2.4 \
+    && GRAALVM_ARTIFACT_VERSION=25i2-25.0.4 \
+    && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/${GRAALVM_RELEASE_TAG}/graalvm-community-jdk-${GRAALVM_ARTIFACT_VERSION}_${GRAALVM_ARCHITECTURE}_bin.tar.gz \
     && wget --no-verbose --output-document=graalvm.tar.gz "${GRAALVM_PKG}" \
     \
     && echo "Checking LTS GraalVM download hash" \
@@ -107,14 +109,16 @@ RUN set -o errexit -o nounset \
     && mv graalvm-* "${JAVA_LTS_HOME}" \
     \
     && echo "Downloading current GraalVM" \
-    && JAVA_CURRENT_VERSION=25.0.2 \
-    && GRAALVM_CURRENT_AMD64_DOWNLOAD_SHA256=e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0 \
-    && GRAALVM_CURRENT_AARCH64_DOWNLOAD_SHA256=b4580d9f223d0a4b3a1757e58b18ff4c1db950e67e105fc5cb741457d2384a71 \
+    && JAVA_CURRENT_VERSION=25.0.4 \
+    && GRAALVM_CURRENT_AMD64_DOWNLOAD_SHA256=3f4a89de8eaa96f2ed677f09957c7e872cd8467aad3537f8b5394c1b8c4b942e \
+    && GRAALVM_CURRENT_AARCH64_DOWNLOAD_SHA256=22286f7ecd21b9aedb3226b9bf797469e1bd3eefc491e12ef3dd49b452d230b7 \
     && if [ "${JAVA_LTS_VERSION}" != "${JAVA_CURRENT_VERSION}" ]; then \
       ARCHITECTURE=$(dpkg --print-architecture) \
       && if [ "${ARCHITECTURE}" = "amd64" ]; then GRAALVM_ARCHITECTURE=linux-x64; fi \
       && if [ "${ARCHITECTURE}" = "arm64" ]; then GRAALVM_ARCHITECTURE=linux-aarch64; fi \
-      && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${JAVA_CURRENT_VERSION}/graalvm-community-jdk-${JAVA_CURRENT_VERSION}_${GRAALVM_ARCHITECTURE}_bin.tar.gz \
+      && GRAALVM_RELEASE_TAG=graal-25.2.4 \
+    && GRAALVM_ARTIFACT_VERSION=25i2-25.0.4 \
+    && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/${GRAALVM_RELEASE_TAG}/graalvm-community-jdk-${GRAALVM_ARTIFACT_VERSION}_${GRAALVM_ARCHITECTURE}_bin.tar.gz \
       && wget --no-verbose --output-document=graalvm.tar.gz "${GRAALVM_PKG}" \
       \
       && echo "Checking current GraalVM download hash" \

--- a/jdk25-noble-graal/Dockerfile
+++ b/jdk25-noble-graal/Dockerfile
@@ -76,17 +76,19 @@ RUN set -o errexit -o nounset \
     && which svn
 
 ENV JAVA_HOME=/opt/java/graalvm
-ENV JAVA_VERSION=25.0.2
+ENV JAVA_VERSION=25.0.4
 RUN set -o errexit -o nounset \
     && mkdir /opt/java \
     \
     && echo "Downloading GraalVM" \
-    && GRAALVM_AMD64_DOWNLOAD_SHA256=e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0 \
-    && GRAALVM_AARCH64_DOWNLOAD_SHA256=b4580d9f223d0a4b3a1757e58b18ff4c1db950e67e105fc5cb741457d2384a71 \
+    && GRAALVM_AMD64_DOWNLOAD_SHA256=3f4a89de8eaa96f2ed677f09957c7e872cd8467aad3537f8b5394c1b8c4b942e \
+    && GRAALVM_AARCH64_DOWNLOAD_SHA256=22286f7ecd21b9aedb3226b9bf797469e1bd3eefc491e12ef3dd49b452d230b7 \
     && ARCHITECTURE=$(dpkg --print-architecture) \
     && if [ "${ARCHITECTURE}" = "amd64" ]; then GRAALVM_ARCHITECTURE=linux-x64; fi \
     && if [ "${ARCHITECTURE}" = "arm64" ]; then GRAALVM_ARCHITECTURE=linux-aarch64; fi \
-    && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${JAVA_VERSION}/graalvm-community-jdk-${JAVA_VERSION}_${GRAALVM_ARCHITECTURE}_bin.tar.gz \
+    && GRAALVM_RELEASE_TAG=graal-25.2.4 \
+    && GRAALVM_ARTIFACT_VERSION=25i2-25.0.4 \
+    && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/${GRAALVM_RELEASE_TAG}/graalvm-community-jdk-${GRAALVM_ARTIFACT_VERSION}_${GRAALVM_ARCHITECTURE}_bin.tar.gz \
     && wget --no-verbose --output-document=graalvm.tar.gz "${GRAALVM_PKG}" \
     \
     && echo "Checking GraalVM download hash" \

--- a/jdk25-resolute-graal/Dockerfile
+++ b/jdk25-resolute-graal/Dockerfile
@@ -76,17 +76,19 @@ RUN set -o errexit -o nounset \
     && which svn
 
 ENV JAVA_HOME=/opt/java/graalvm
-ENV JAVA_VERSION=25.0.2
+ENV JAVA_VERSION=25.0.4
 RUN set -o errexit -o nounset \
     && mkdir /opt/java \
     \
     && echo "Downloading GraalVM" \
-    && GRAALVM_AMD64_DOWNLOAD_SHA256=e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0 \
-    && GRAALVM_AARCH64_DOWNLOAD_SHA256=b4580d9f223d0a4b3a1757e58b18ff4c1db950e67e105fc5cb741457d2384a71 \
+    && GRAALVM_AMD64_DOWNLOAD_SHA256=3f4a89de8eaa96f2ed677f09957c7e872cd8467aad3537f8b5394c1b8c4b942e \
+    && GRAALVM_AARCH64_DOWNLOAD_SHA256=22286f7ecd21b9aedb3226b9bf797469e1bd3eefc491e12ef3dd49b452d230b7 \
     && ARCHITECTURE=$(dpkg --print-architecture) \
     && if [ "${ARCHITECTURE}" = "amd64" ]; then GRAALVM_ARCHITECTURE=linux-x64; fi \
     && if [ "${ARCHITECTURE}" = "arm64" ]; then GRAALVM_ARCHITECTURE=linux-aarch64; fi \
-    && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${JAVA_VERSION}/graalvm-community-jdk-${JAVA_VERSION}_${GRAALVM_ARCHITECTURE}_bin.tar.gz \
+    && GRAALVM_RELEASE_TAG=graal-25.2.4 \
+    && GRAALVM_ARTIFACT_VERSION=25i2-25.0.4 \
+    && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/${GRAALVM_RELEASE_TAG}/graalvm-community-jdk-${GRAALVM_ARTIFACT_VERSION}_${GRAALVM_ARCHITECTURE}_bin.tar.gz \
     && wget --no-verbose --output-document=graalvm.tar.gz "${GRAALVM_PKG}" \
     \
     && echo "Checking GraalVM download hash" \

--- a/toolbox.ps1
+++ b/toolbox.ps1
@@ -1,0 +1,16 @@
+$buildOutput = & docker build --pull --tag gradle-dockerhub-toolbox -f toolbox/Dockerfile toolbox 2>&1
+
+if ($LASTEXITCODE -ne 0) {
+    [Console]::Error.WriteLine(($buildOutput -join [Environment]::NewLine))
+    [Console]::Error.WriteLine('Failed to build gradle-dockerhub-toolbox image')
+    exit 1
+}
+
+& docker run --rm -ti `
+    -v "$($PWD.Path):/workspace" `
+    -e GITHUB_TOKEN `
+    -w /workspace `
+    gradle-dockerhub-toolbox `
+    python3 @args
+
+exit $LASTEXITCODE

--- a/update.py
+++ b/update.py
@@ -53,21 +53,47 @@ def get_sha256(url):
             return calculate_sha256(binary_url)
         raise
 
-def get_graalvm_info(jdk_version):
-    url = "https://api.github.com/repos/graalvm/graalvm-ce-builds/releases?per_page=20&page=1"
-    response = requests.get(url, timeout=10, headers=github_headers(url))
-    response.raise_for_status()
-    releases = response.json()
+GRAALVM_RELEASES_URL = "https://api.github.com/repos/graalvm/graalvm-ce-builds/releases?per_page=100"
+GRAALVM_ASSET_PATTERN = re.compile(
+    r"^graalvm-community-jdk-(?P<artifact_version>.+)_linux-(?P<architecture>x64|aarch64)_bin\.tar\.gz$"
+)
+GRAALVM_TAG_PATTERN = re.compile(r"^(?:jdk|graal)-(?P<version>\d+(?:\.\d+)+)$")
 
-    tag_prefix = f"jdk-{jdk_version}"
-    matching_releases = [r for r in releases if tag_prefix in r['tag_name']]
+def get_graalvm_info(jdk_version):
+    matching_releases = []
+    url = f"{GRAALVM_RELEASES_URL}&page=1"
+    while url:
+        response = requests.get(url, timeout=10, headers=github_headers(url))
+        response.raise_for_status()
+        releases = response.json()
+        url = response.links.get('next', {}).get('url')
+        for release in releases:
+            if release.get('draft') or release.get('prerelease'):
+                continue
+            tag_match = GRAALVM_TAG_PATTERN.match(release['tag_name'])
+            if not tag_match:
+                continue
+            matching_assets = {}
+            for asset in release.get('assets', []):
+                match = GRAALVM_ASSET_PATTERN.match(asset['name'])
+                if not match:
+                    continue
+                artifact_version = match.group('artifact_version')
+                jdk_release_version = artifact_version.rsplit('-', 1)[-1]
+                if jdk_release_version == jdk_version or jdk_release_version.startswith(f"{jdk_version}."):
+                    matching_assets[match.group('architecture')] = (asset, artifact_version, jdk_release_version)
+            if {'x64', 'aarch64'} <= matching_assets.keys():
+                amd64_asset, artifact_version, jdk_release_version = matching_assets['x64']
+                aarch64_asset, aarch64_artifact_version, aarch64_jdk_release_version = matching_assets['aarch64']
+                if artifact_version != aarch64_artifact_version or jdk_release_version != aarch64_jdk_release_version:
+                    continue
+                version = tuple(int(part) for part in tag_match.group('version').split('.'))
+                matching_releases.append((version, release['tag_name'], artifact_version, jdk_release_version, amd64_asset, aarch64_asset))
     if not matching_releases:
         raise Exception(f"No GraalVM release found for JDK {jdk_version}")
 
-    tag_name = matching_releases[0]['tag_name']
-    version = tag_name.replace("jdk-", "")
-
-    return version
+    _, tag_name, artifact_version, jdk_release_version, amd64_asset, aarch64_asset = max(matching_releases, key=lambda release: release[0])
+    return tag_name, artifact_version, jdk_release_version, amd64_asset['browser_download_url'], aarch64_asset['browser_download_url']
 
 def update_file(filepath, pattern, replacement):
     if not os.path.exists(filepath):
@@ -83,28 +109,36 @@ def update_file(filepath, pattern, replacement):
             f.write(new_content)
 
 def fetch_graalvm_release_info(jdk_version):
-    version = get_graalvm_info(jdk_version)
-    amd64_sha = get_sha256(f"https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-{version}/graalvm-community-jdk-{version}_linux-x64_bin.tar.gz.sha256")
-    aarch64_sha = get_sha256(f"https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-{version}/graalvm-community-jdk-{version}_linux-aarch64_bin.tar.gz.sha256")
+    tag_name, artifact_version, jdk_release_version, amd64_url, aarch64_url = get_graalvm_info(jdk_version)
+    amd64_sha = get_sha256(f"{amd64_url}.sha256")
+    aarch64_sha = get_sha256(f"{aarch64_url}.sha256")
 
-    print(f"Latest Graal {jdk_version} version is {version}")
+    print(f"Latest Graal {jdk_version} release is {tag_name}")
     print(f"Graal {jdk_version} AMD64 hash is {amd64_sha}")
     print(f"Graal {jdk_version} AARCH64 hash is {aarch64_sha}")
     print()
 
-    return version, amd64_sha, aarch64_sha
+    return jdk_release_version, tag_name, artifact_version, amd64_sha, aarch64_sha
 
-def update_graalvm_dockerfiles(dir_names, version, amd64_sha, aarch64_sha, env_prefix=""):
+def update_graalvm_dockerfiles(dir_names, version, tag_name, artifact_version, amd64_sha, aarch64_sha, env_prefix=""):
     for dir_name in dir_names:
         filepath = os.path.join(dir_name, "Dockerfile")
         if env_prefix:
+            java_version = f"${{JAVA_{env_prefix}_VERSION}}"
             update_file(filepath, rf"JAVA_{env_prefix}_VERSION=\S+", f"JAVA_{env_prefix}_VERSION={version}")
             update_file(filepath, rf"GRAALVM_{env_prefix}_AMD64_DOWNLOAD_SHA256=\S+", f"GRAALVM_{env_prefix}_AMD64_DOWNLOAD_SHA256={amd64_sha}")
             update_file(filepath, rf"GRAALVM_{env_prefix}_AARCH64_DOWNLOAD_SHA256=\S+", f"GRAALVM_{env_prefix}_AARCH64_DOWNLOAD_SHA256={aarch64_sha}")
         else:
+            java_version = "${JAVA_VERSION}"
             update_file(filepath, r"ENV JAVA_VERSION=\S+", f"ENV JAVA_VERSION={version}")
             update_file(filepath, r"GRAALVM_AMD64_DOWNLOAD_SHA256=\S+", f"GRAALVM_AMD64_DOWNLOAD_SHA256={amd64_sha}")
             update_file(filepath, r"GRAALVM_AARCH64_DOWNLOAD_SHA256=\S+", f"GRAALVM_AARCH64_DOWNLOAD_SHA256={aarch64_sha}")
+        package_pattern = r"(?:GRAALVM_RELEASE_TAG=\S+ \\\n\s*&& GRAALVM_ARTIFACT_(?:VERSION|PREFIX)=\S+ \\\n\s*&& )?GRAALVM_PKG=https://github\.com/graalvm/graalvm-ce-builds/releases/download/[^\s]+"
+        if tag_name == f"jdk-{version}" and artifact_version == version:
+            package_replacement = f"GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-{java_version}/graalvm-community-jdk-{java_version}_${{GRAALVM_ARCHITECTURE}}_bin.tar.gz"
+        else:
+            package_replacement = f"GRAALVM_RELEASE_TAG={tag_name} \\\n    && GRAALVM_ARTIFACT_VERSION={artifact_version} \\\n    && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/${{GRAALVM_RELEASE_TAG}}/graalvm-community-jdk-${{GRAALVM_ARTIFACT_VERSION}}_${{GRAALVM_ARCHITECTURE}}_bin.tar.gz"
+        update_file(filepath, package_pattern, package_replacement)
 
 def main():
     version_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'version.txt')
@@ -138,27 +172,27 @@ def main():
         return
 
     # GraalVM updates
-    graal17_version, graal17_amd64_sha, graal17_aarch64_sha = fetch_graalvm_release_info("17")
-    update_graalvm_dockerfiles(["jdk17-noble-graal", "jdk17-resolute-graal", "jdk17-jammy-graal"], graal17_version, graal17_amd64_sha, graal17_aarch64_sha)
+    graal17_info = fetch_graalvm_release_info("17")
+    update_graalvm_dockerfiles(["jdk17-noble-graal", "jdk17-resolute-graal", "jdk17-jammy-graal"], *graal17_info)
 
     if base_version < 8:
         return
 
-    graal21_version, graal21_amd64_sha, graal21_aarch64_sha = fetch_graalvm_release_info("21")
-    update_graalvm_dockerfiles(["jdk21-noble-graal", "jdk21-resolute-graal", "jdk21-jammy-graal"], graal21_version, graal21_amd64_sha, graal21_aarch64_sha)
+    graal21_info = fetch_graalvm_release_info("21")
+    update_graalvm_dockerfiles(["jdk21-noble-graal", "jdk21-resolute-graal", "jdk21-jammy-graal"], *graal21_info)
 
     if base_version < 9:
-        graal24_version, graal24_amd64_sha, graal24_aarch64_sha = fetch_graalvm_release_info("24")
-        update_graalvm_dockerfiles(["jdk24-noble-graal"], graal24_version, graal24_amd64_sha, graal24_aarch64_sha)
+        graal24_info = fetch_graalvm_release_info("24")
+        update_graalvm_dockerfiles(["jdk24-noble-graal"], *graal24_info)
 
-        update_graalvm_dockerfiles(["jdk-lts-and-current-graal"], graal21_version, graal21_amd64_sha, graal21_aarch64_sha, env_prefix="21")
-        update_graalvm_dockerfiles(["jdk-lts-and-current-graal"], graal24_version, graal24_amd64_sha, graal24_aarch64_sha, env_prefix="24")
+        update_graalvm_dockerfiles(["jdk-lts-and-current-graal"], *graal21_info, env_prefix="21")
+        update_graalvm_dockerfiles(["jdk-lts-and-current-graal"], *graal24_info, env_prefix="24")
     else:
-        graal25_version, graal25_amd64_sha, graal25_aarch64_sha = fetch_graalvm_release_info("25")
-        update_graalvm_dockerfiles(["jdk25-noble-graal", "jdk25-resolute-graal"], graal25_version, graal25_amd64_sha, graal25_aarch64_sha)
+        graal25_info = fetch_graalvm_release_info("25")
+        update_graalvm_dockerfiles(["jdk25-noble-graal", "jdk25-resolute-graal"], *graal25_info)
 
-        update_graalvm_dockerfiles(["jdk-lts-and-current-graal"], graal25_version, graal25_amd64_sha, graal25_aarch64_sha, env_prefix="LTS")
-        update_graalvm_dockerfiles(["jdk-lts-and-current-graal"], graal25_version, graal25_amd64_sha, graal25_aarch64_sha, env_prefix="CURRENT")
+        update_graalvm_dockerfiles(["jdk-lts-and-current-graal"], *graal25_info, env_prefix="LTS")
+        update_graalvm_dockerfiles(["jdk-lts-and-current-graal"], *graal25_info, env_prefix="CURRENT")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## What changed

- Adds a PowerShell toolbox wrapper for the containerized update script.
- Updates the managed GraalVM versions.
- Makes GraalVM release discovery support both legacy `jdk-*` tags and current `graal-*` tags.

## Why

GraalVM 25 Innovation releases use `graal-*` release tags and artifact names that differ from the legacy JDK-tagged releases. The updater previously skipped those releases and selected the older 25.0.2 release.

## Validation

- Ran a focused mocked old/new release-tag selection test.
- Ran `python -m py_compile update.py`.
- Verified live API resolution for GraalVM 25 returns `graal-25.2.4`.